### PR TITLE
unicode is str in Python 3

### DIFF
--- a/aws_role_credentials/models.py
+++ b/aws_role_credentials/models.py
@@ -65,10 +65,13 @@ class AwsCredentialsFile:
             config.write(configfile)
 
     def add_profile(self, name, region, credentials):
-        name = unicode(name)
-        self._add_profile(name, {u'output': u'json',
-                                 u'region': unicode(region),
-                                 u'aws_access_key_id': unicode(credentials.access_key),
-                                 u'aws_secret_access_key': unicode(credentials.secret_key),
-                                 u'aws_security_token': unicode(credentials.session_token),
-                                 u'aws_session_token': unicode(credentials.session_token)})
+        name = str(name)
+        self._add_profile(
+            name, {
+                u'output': u'json',
+                u'region': str(region),
+                u'aws_access_key_id': str(credentials.access_key),
+                u'aws_secret_access_key': str(credentials.secret_key),
+                u'aws_security_token': str(credentials.session_token),
+                u'aws_session_token': str(credentials.session_token)
+            })


### PR DESCRIPTION
There's no reason to support Python 2 anymore. Hence skipping
compatibility.